### PR TITLE
Add MkDocs-powered documentation site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,38 @@
+name: Deploy documentation site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Build and deploy
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ EveNet is a multi-task, event-level neural network for large-scale high-energy p
 
 ---
 
+## 📚 Documentation Website
+
+The Markdown guides in `docs/` now power a GitHub Pages site via [MkDocs](https://www.mkdocs.org/). After every push to `main`,
+the automated "Deploy documentation site" workflow rebuilds the static site and publishes it to the `gh-pages` branch for GitHub Pages.
+
+### Preview locally
+
+```bash
+pip install mkdocs mkdocs-material pymdown-extensions
+mkdocs serve
+```
+
+Then open http://127.0.0.1:8000/ in your browser to browse the docs with live reload while you edit Markdown files.
+
+### Publish manually (optional)
+
+If you need to deploy without waiting for CI, run:
+
+```bash
+mkdocs gh-deploy --force
+```
+
+This pushes the built site to `gh-pages` using your local Git credentials.
+
+---
+
 ## 🚀 Quickstart Workflow
 
 1. **Start from the prebuilt Docker image (recommended).** Pull the GPU-enabled container so CUDA, PyTorch, and system libraries are preconfigured.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# EveNet Documentation Portal
+
+Welcome to the EveNet knowledge base! This site hosts the same Markdown guides that live in the repository, but it formats them with navigation, search, and table-of-contents support so new collaborators can onboard quickly.
+
+Use the navigation menu to jump straight to the guide you need, or start with the highlights below.
+
+## 🚀 Quick Starts
+
+- **New contributor?** Begin with the [Getting Started tutorial](getting_started.md) for a tour of the repo, environment setup, and the end-to-end workflow from preprocessing to inference.
+- **Prepping datasets?** Head to the [Data Preparation guide](data_preparation.md) to learn how to configure preprocessing YAMLs and generate parquet shards.
+- **Training & inference.** Consult the [Training playbook](train.md) and [Prediction walkthrough](predict.md) for command-line examples and Ray configuration tips.
+
+## 🧠 Reference Library
+
+- **Architecture deep dive.** The [Model Architecture overview](model_architecture.md) explains the hybrid point-cloud and global feature encoders that power EveNet.
+- **Configuration catalogue.** The [Configuration reference](configuration.md) documents every YAML option and how they interact.
+- **Internal utilities.** Project maintainers can review [internal preprocessing notes](preprocess_internal_only.md) for NERSC-specific helpers.
+
+## 🔄 Keeping Docs in Sync
+
+The MkDocs configuration (`mkdocs.yml`) reads directly from the `docs/` folder, so improvements to the Markdown files automatically flow to the website. When you update a guide, commit the change and the GitHub Pages workflow will rebuild the site.
+
+Looking to preview locally? See the README for the commands to install MkDocs and run `mkdocs serve`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,23 @@
+site_name: EveNet Documentation Portal
+site_description: "Guides and references for installing, training, and deploying EveNet."
+# Update `site_url` once the repository lives under a permanent GitHub organization/user.
+site_url: ""
+nav:
+  - Home: index.md
+  - Getting Started: getting_started.md
+  - Data Preparation: data_preparation.md
+  - Model Architecture: model_architecture.md
+  - Training: train.md
+  - Prediction: predict.md
+  - Configuration Reference: configuration.md
+  - Internal Notes: preprocess_internal_only.md
+theme:
+  name: readthedocs
+repo_url: https://github.com/<your-org>/EveNet_NERSC
+repo_name: EveNet_NERSC
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences


### PR DESCRIPTION
## Summary
- introduce a MkDocs configuration and docs landing page so the existing markdown files can be published as a documentation site
- add a GitHub Actions workflow that builds the docs with MkDocs and deploys them to `gh-pages` on pushes to `main`
- document how to preview and manually deploy the site from the README

## Testing
- not run (MkDocs not available in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68df8492e2748331ab68bb7e631234f8