### PR TITLE
Add MkDocs override to disable browser caching

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Internal Notes: preprocess_internal_only.md
 theme:
   name: readthedocs
+  custom_dir: docs/overrides
 repo_url: https://github.com/<your-org>/EveNet_Public
 repo_name: EveNet_Public
 markdown_extensions:


### PR DESCRIPTION
## Summary
- add a MkDocs theme override that injects cache-busting meta tags
- configure MkDocs to use the new override directory so GitHub Pages serves fresh content

## Testing
- not run (mkdocs is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df8f6ef81883319b292c32cd4b39a5