### PR TITLE
Adjust packaging metadata to avoid enforcing GPU dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,36 @@ EveNet is a multi-task, event-level neural network for large-scale high-energy p
 
 ---
 
+## 🚀 Installation
+
+EveNet is now packaged as a Python module. Install it directly from PyPI (or a local checkout while developing) and the CLI entry points become available automatically:
+
+```bash
+pip install evenet
+```
+
+For local development you can install the current repository in editable mode:
+
+```bash
+pip install -e .
+```
+
+> **Note:** The package intentionally does not declare the full CUDA / GPU software stack as dependencies. Provision the execution environment yourself—either by using the Docker image under [`Docker/`](Docker/) or by installing the requirements from [`requirements.txt`](requirements.txt) / [`requirement_docker.txt`](requirement_docker.txt) on compatible hardware before launching the CLI.
+
+## 🛠️ Command line interface
+
+The package exposes training and prediction helpers so experiments can be launched without Python boilerplate. Provide the same YAML configuration files that power the existing workflows.
+
+```bash
+# Launch distributed training with Ray + Lightning
+evenet-train path/to/config.yaml --ray_dir ~/ray_results
+
+# Run inference with a trained checkpoint
+evenet-predict path/to/predict_config.yaml
+```
+
+---
+
 ## 🤝 Contributing
 
 Improvements are welcome! File an issue or open a pull request for bug fixes, new physics processes, or documentation tweaks. When you add new components or datasets, update the relevant markdown guides so future users can follow along easily.

--- a/evenet/__init__.py
+++ b/evenet/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for EveNet."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/evenet/train.py
+++ b/evenet/train.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 from pathlib import Path
+from typing import Optional, Sequence
 
 import ray
 import ray.train
@@ -19,7 +20,7 @@ from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint, Learning
 from lightning.pytorch.profilers import PyTorchProfiler
 
 from evenet.control.global_config import global_config
-from shared import make_process_fn, prepare_datasets, EveNetTrainCallback
+from .shared import make_process_fn, prepare_datasets, EveNetTrainCallback
 from evenet.engine import EveNetEngine
 from evenet.utilities.logger import LocalLogger, setup_logging
 
@@ -220,13 +221,30 @@ def main(args):
         dist.destroy_process_group()
 
 
-if __name__ == '__main__':
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="EveNet Training Program")
     parser.add_argument("config", help="Path to config file")
-    # argument for loading all dataset files into RAM
-    parser.add_argument("--load_all", action="store_true", help="Load all dataset files into RAM")
-    parser.add_argument("--ray_dir", type=str, default="~/ray_results")
+    parser.add_argument(
+        "--load_all",
+        action="store_true",
+        help="Load all dataset files into RAM",
+    )
+    parser.add_argument(
+        "--ray_dir",
+        type=str,
+        default="~/ray_results",
+        help="Directory where Ray runtime artifacts are stored",
+    )
+    return parser
 
-    args, _ = parser.parse_known_args()
 
+def cli(argv: Optional[Sequence[str]] = None) -> None:
+    """Console script entry point for EveNet training."""
+
+    parser = build_parser()
+    args, _ = parser.parse_known_args(argv)
     main(args)
+
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "evenet"
+version = "0.1.0"
+description = "EveNet training and inference toolkit for event-level physics modeling"
+readme = "README.md"
+authors = [
+    { name = "EveNet Team" },
+]
+requires-python = ">=3.10"
+license = { text = "UNLICENSED" }
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "License :: Other/Proprietary License",
+    "Operating System :: OS Independent",
+]
+
+
+[project.urls]
+Homepage = "https://uw-epe-ml.github.io/EveNet_Public/"
+Repository = "https://github.com/uw-epe-ml/EveNet_Public"
+
+[project.scripts]
+evenet-train = "evenet.train:cli"
+evenet-predict = "evenet.predict:cli"
+
+[tool.setuptools.packages.find]
+include = ["evenet*"]


### PR DESCRIPTION
## Summary
- remove the runtime dependency list from `pyproject.toml` so users can provision the CUDA-enabled stack themselves
- document that the package expects users to prepare the environment via Docker or manual installation before running the CLI

## Testing
- python -m compileall evenet

------
https://chatgpt.com/codex/tasks/task_e_68dfcc2509888331b1703b35982e4ffa