### PR TITLE
Target Python 3.12 and enable automated PyPI publishing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,51 @@
+name: Build and Publish Python Package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: evenet-dist
+          path: dist/*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: evenet-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ Start directly from pretrained EveNet checkpoints for fine-tuning or inference:
 
 ---
 
+## 📦 Python Package Distribution
+
+The repository now ships as a lightweight Python package that exposes ready-to-run CLI entry points for
+training and prediction. We intentionally **do not declare runtime dependencies** in `pyproject.toml`
+because EveNet targets GPU-enabled environments that often require bespoke CUDA, PyTorch, and Ray
+builds. Create your own virtual environment on **Python 3.12+** or use one of the provided Docker images
+before installing EveNet.
+
+```bash
+pip install .
+```
+
+After installation you can launch the existing Ray/Lightning workflows directly from the command line:
+
+```bash
+# Start a training run
+evenet-train share/configs/train.yaml --ray_dir ~/ray_results
+
+# Run inference
+evenet-predict share/configs/predict.yaml
+```
+
+Both CLIs expect the same YAML configuration files documented in [`docs/train.md`](docs/train.md) and
+[`docs/predict.md`](docs/predict.md). Ensure your environment has access to GPUs (where required) and
+the appropriate dataset shards referenced in the configuration.
+
+### 🔄 Publishing to PyPI via GitHub Actions
+
+This repository ships with a workflow that builds wheels and source distributions on every push and PR.
+To automatically publish the package to PyPI when a release is published:
+
+1. Generate a PyPI token with project-scoped permissions.
+2. Add the token to the repository secrets as `PYPI_API_TOKEN`.
+3. Create and publish a GitHub Release (backed by a tag). The workflow uploads the previously built
+   distribution artifacts with that token.
+
+---
+
 ## 🤝 Contributing
 
 Improvements are welcome! File an issue or open a pull request for bug fixes, new physics processes, or documentation tweaks. When you add new components or datasets, update the relevant markdown guides so future users can follow along easily.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,7 +25,7 @@ Before running any commands, skim these key directories:
      -v $(pwd):/workspace/project \
      docker.io/avencast1994/evenet:1.3
    ```
-   Inside the container, switch to `/workspace/project` to use your local checkout. If Docker is unavailable, install dependencies manually with `pip install -r requirements.txt` on Python 3.10+.
+   Inside the container, switch to `/workspace/project` to use your local checkout. If Docker is unavailable, install dependencies manually with `pip install -r requirements.txt` on Python 3.12+.
 2. **Review cluster helpers as needed.** The `Docker/` and `NERSC/` directories include recipes and SLURM launch scripts tailored for HPC environments.
 3. **Verify GPU visibility (if available).**
    ```bash
@@ -74,9 +74,10 @@ See [data preparation guide](data_preparation.md) for details on schema, normali
    ```bash
    export WANDB_API_KEY=<your_key>
    ```
-2. Launch training with your updated YAML.
+2. Launch training with your updated YAML. After installing the EveNet package (`pip install .`),
+   you can invoke the packaged CLI directly:
    ```bash
-   python evenet/train.py path/to/your-train-config.yaml
+   evenet-train path/to/your-train-config.yaml
    ```
 3. Monitor progress:
    - Console output provides per-epoch metrics and checkpoint locations.
@@ -88,9 +89,9 @@ See [data preparation guide](data_preparation.md) for details on schema, normali
 ## 7. Generate Predictions
 
 1. Ensure the prediction YAML points to your trained (or pretrained) checkpoint via `options.Training.model_checkpoint_load_path`.
-2. Launch inference.
+2. Launch inference with the packaged CLI.
    ```bash
-   python evenet/predict.py path/to/your-predict-config.yaml
+   evenet-predict path/to/your-predict-config.yaml
    ```
 3. Outputs land in the configured writers (e.g., parquet, numpy archives). See `docs/predict.md` for writer options and schema notes.
 

--- a/docs/predict.md
+++ b/docs/predict.md
@@ -1,0 +1,3 @@
+# Prediction
+
+> 🚀 **Quickstart:** After `pip install .`, launch inference with `evenet-predict <config.yaml>`.

--- a/docs/train.md
+++ b/docs/train.md
@@ -1,5 +1,7 @@
 # Training
 
+> 🚀 **Quickstart:** After `pip install .`, launch training with `evenet-train <config.yaml>`.
+
 ## Loading and Saving Models
 
 This guide outlines how model weights and Exponential Moving Average (EMA) weights are handled in the training workflow.

--- a/evenet/__init__.py
+++ b/evenet/__init__.py
@@ -1,0 +1,4 @@
+"""EveNet package exposing training and prediction entry points."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/evenet/train.py
+++ b/evenet/train.py
@@ -19,7 +19,7 @@ from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint, Learning
 from lightning.pytorch.profilers import PyTorchProfiler
 
 from evenet.control.global_config import global_config
-from shared import make_process_fn, prepare_datasets, EveNetTrainCallback
+from evenet.shared import make_process_fn, prepare_datasets, EveNetTrainCallback
 from evenet.engine import EveNetEngine
 from evenet.utilities.logger import LocalLogger, setup_logging
 
@@ -139,7 +139,16 @@ def train_func(cfg):
     )
 
 
-def main(args):
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="EveNet Training Program")
+    parser.add_argument("config", help="Path to config file")
+    # argument for loading all dataset files into RAM
+    parser.add_argument("--load_all", action="store_true", help="Load all dataset files into RAM")
+    parser.add_argument("--ray_dir", type=str, default="~/ray_results")
+    return parser
+
+
+def main(args: argparse.Namespace) -> None:
     assert (
             "WANDB_API_KEY" in os.environ
     ), 'Please set WANDB_API_KEY="abcde" when running this script.'
@@ -220,13 +229,11 @@ def main(args):
         dist.destroy_process_group()
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="EveNet Training Program")
-    parser.add_argument("config", help="Path to config file")
-    # argument for loading all dataset files into RAM
-    parser.add_argument("--load_all", action="store_true", help="Load all dataset files into RAM")
-    parser.add_argument("--ray_dir", type=str, default="~/ray_results")
-
+def cli() -> None:
+    parser = build_parser()
     args, _ = parser.parse_known_args()
-
     main(args)
+
+
+if __name__ == '__main__':
+    cli()

--- a/preprocessing/__init__.py
+++ b/preprocessing/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for preparing EveNet training datasets."""
+
+__all__ = [
+    "convert_evenet_to_spanet",
+    "evenet_data_converter",
+    "monitor_gen_matching",
+    "postprocessor",
+    "preprocess",
+    "process_info",
+    "dqm_util",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "evenet"
+version = "0.1.0"
+description = "Training and inference entry points for the EveNet event processing model."
+readme = "README.md"
+requires-python = ">=3.12"
+authors = [{name = "EveNet Team"}]
+dependencies = []
+
+[project.scripts]
+evenet-train = "evenet.train:cli"
+evenet-predict = "evenet.predict:cli"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["evenet"]


### PR DESCRIPTION
## Summary
- require Python 3.12+ for the packaged EveNet module and exclude preprocessing utilities from builds
- document the Python 3.12 environment requirement and describe how to publish releases via GitHub Actions
- update the packaging workflow to use Python 3.12 and publish to PyPI whenever a release is published

## Testing
- python -m compileall evenet

------
https://chatgpt.com/codex/tasks/task_e_68dfd0e5257c8331838aa3da44a3fbdc