### PR TITLE
Add log scaling for log_normalize features during preprocessing

### DIFF
--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -43,9 +43,10 @@ ingests and to clarify how each tensor maps onto the model heads.
 4. **Train or evaluate.** Training configs reference the resulting parquet directory via `platform.data_parquet_dir` and
    reuse the same YAML in `options.Dataset.event_info`.
 
-> ✨ **Normalization note.** The `normalize`, `log_normalize`, and `none` tags in the YAML are metadata only. EveNet
-> derives channel-wise statistics during conversion. The sole special case is `normalize_uniform`, which reserves a
-> transformation for circular variables (`φ`); the model automatically maps to and from the wrapped representation.
+> ✨ **Normalization note.** Features marked `log_normalize` in the YAML are converted with `np.log1p` during
+> preprocessing (converter logs the affected columns). Values must be finite and non-negative or the run will fail so
+> you can fix the upstream pipeline. Other tags (`normalize`, `none`) remain metadata only, while `normalize_uniform`
+> still denotes the wrapped representation for circular variables (`φ`).
 
 ---
 

--- a/preprocessing/helper.py
+++ b/preprocessing/helper.py
@@ -22,6 +22,23 @@ logger = logging.getLogger(__name__)
 # ======================================================================
 # Utility Helpers
 # ======================================================================
+@dataclass
+class LogScalePlan:
+    sequential_indices: list[int] = field(default_factory=list)
+    sequential_names: list[str] = field(default_factory=list)
+    condition_indices: list[int] = field(default_factory=list)
+    condition_names: list[str] = field(default_factory=list)
+    invisible_indices: list[int] = field(default_factory=list)
+    invisible_names: list[str] = field(default_factory=list)
+
+    def description(self) -> str:
+        sequential = ", ".join(self.sequential_names) if self.sequential_names else "<none>"
+        conditions = ", ".join(self.condition_names) if self.condition_names else "<none>"
+        invisible = ", ".join(self.invisible_names) if self.invisible_names else "<none>"
+        return (
+            f"x → {sequential}; conditions → {conditions}; invisible → {invisible}"
+        )
+
 
 def load_npz(path):
     arr = np.load(path, allow_pickle=True)
@@ -104,24 +121,6 @@ def apply_log_scaling(pdict: dict, plan: LogScalePlan) -> dict:
         )
 
     return pdict
-
-
-@dataclass
-class LogScalePlan:
-    sequential_indices: list[int] = field(default_factory=list)
-    sequential_names: list[str] = field(default_factory=list)
-    condition_indices: list[int] = field(default_factory=list)
-    condition_names: list[str] = field(default_factory=list)
-    invisible_indices: list[int] = field(default_factory=list)
-    invisible_names: list[str] = field(default_factory=list)
-
-    def description(self) -> str:
-        sequential = ", ".join(self.sequential_names) if self.sequential_names else "<none>"
-        conditions = ", ".join(self.condition_names) if self.condition_names else "<none>"
-        invisible = ", ".join(self.invisible_names) if self.invisible_names else "<none>"
-        return (
-            f"x → {sequential}; conditions → {conditions}; invisible → {invisible}"
-        )
 
 
 def event_split_indices(n_events, ratio, rng=None):


### PR DESCRIPTION
## Summary
- apply `np.log1p` to all features flagged with `log_normalize` in the event-info config before statistics and flattening
- validate log-scaled inputs for non-finite or negative values and log the affected columns
- update data preparation docs to describe the automatic log scaling behavior

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb88ee8348331ac21ff8db8d6e590)